### PR TITLE
Add sources to ffunctions Extension in the correct order of compilation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,13 @@ from numpy.distutils.core import setup
 from numpy.distutils.core import Extension
 
 ffunctions = Extension(name='llg.ffunctions',
-                       sources=['fortran-src/signature.pyf'] + glob("fortran-src/*.f90"))
-
+                       sources=['fortran-src/signature.pyf'] +
+                       glob("fortran-src/ffunctions*") +
+                       glob("fortran-src/*.c") +
+                       ["fortran-src/external_fields.f90",
+                        "fortran-src/mag_functions.f90",
+                        "fortran-src/spin_fields.f90",
+                        "fortran-src/heun.f90"])
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()


### PR DESCRIPTION
When a Fortran module uses other modules, these have to be compiled first. This order of compilation was not ensured in the `setup.py` file. I propose we ensure this order manually for now.